### PR TITLE
fix(ariel): use BTreeMap for crate Manifest tables

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -32,8 +32,8 @@ impl Crate {
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Manifest {
     pub package: Package,
-    pub dependencies: HashMap<String, Dependency>,
-    pub features: HashMap<String, Vec<String>>,
+    pub dependencies: BTreeMap<String, Dependency>,
+    pub features: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/src/snapshots/sbd_gen__tests__sbd_ariel.snap
+++ b/src/snapshots/sbd_gen__tests__sbd_ariel.snap
@@ -4,7 +4,7 @@ expression: ariel
 ---
 FileMap {
     map: {
-        "Cargo.toml": "[package]\nname = \"ariel-os-boards\"\n\n[package.edition]\nworkspace = true\n\n[package.license]\nworkspace = true\n\n[package.rust-version]\nworkspace = true\n\n[dependencies.cfg-if]\nworkspace = true\n\n[dependencies.ariel-os-hal]\nworkspace = true\n\n[dependencies.ariel-os-embassy-common]\nworkspace = true\n\n[features]\nno-boards = []\n",
+        "Cargo.toml": "[package]\nname = \"ariel-os-boards\"\n\n[package.edition]\nworkspace = true\n\n[package.license]\nworkspace = true\n\n[package.rust-version]\nworkspace = true\n\n[dependencies.ariel-os-embassy-common]\nworkspace = true\n\n[dependencies.ariel-os-hal]\nworkspace = true\n\n[dependencies.cfg-if]\nworkspace = true\n\n[features]\nno-boards = []\n",
         "build.rs": "// @generated\npub fn main() {\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"nrf52840dk\\\"))\");\n}\n",
         "laze.yml": "# yamllint disable-file\n\nbuilders:\n- name: nrf52840dk\n  parent: nrf52840\n  provides:\n  - has_buttons\n  - has_leds\n  - has_usb_device_port\n",
         "src/lib.rs": "// @generated\n\n#![no_std]\n\ncfg_if::cfg_if! {\n    if #[cfg(context = \"nrf52840dk\")] {\n        include!(\"nrf52840dk.rs\");\n    } else {\n        // TODO\n    }\n}\n",


### PR DESCRIPTION
`HashMap` is not stable, leading to indeterministic output, breaking snapshot tests and `check` mode.