### PR TITLE
refactor: accept Clippy fix

### DIFF
--- a/src/riot.rs
+++ b/src/riot.rs
@@ -227,7 +227,7 @@ fn generate_riot_board(sbd: &SbdFile, board: &Board) -> Result<RiotBoard> {
     for (filename, file_obj) in quirk_file_map {
         if let Some(quirk) = riot_chip.quirks.get(filename) {
             for snip in &quirk.body {
-                file_obj.content_snips.push(snip.to_string());
+                file_obj.content_snips.push(snip.clone());
             }
         }
     }


### PR DESCRIPTION
#57 tripped over this; it's a legitimate fix b/c to_string generally converts to strings like the inverse of parsing, and this already is a string.