### PR TITLE
feat: make schema version separate from schema crate version

### DIFF
--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -19,13 +19,14 @@ const fn default_version() -> Version {
 }
 
 /// Returns the used schema version.
+///
+/// - If the new schema adds new functionality but doesn't break old schema files: only a non-SemVer-breaking bump is required
+/// - Otherwise, this needs a SemVer-breaking bump.
+///
+/// In both cases, the schema version must be updated accordingly.
 #[must_use]
-pub fn schema_version() -> Version {
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "this is expected to be correct at compile time"
-    )]
-    Version::parse(env!("CARGO_PKG_VERSION")).unwrap()
+pub const fn schema_version() -> Version {
+    semver::Version::new(0, 3, 1)
 }
 
 #[serde_as]


### PR DESCRIPTION
https://github.com/ariel-os/sbd/pull/68 changed the schema crate API but technically would not require a breaking version bump. Releaze-plz correctly break bumped the schema crate version as the crate API is breaking.

Before this PR, the schema version was tied to the schema crate version.
This PR unties that.