### PR TITLE
feat(schema)!: make ledN, buttonN and uartN names implicit

### DIFF
--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -63,10 +63,10 @@ pub struct Target {
     pub debugger: Option<Debugger>,
 
     // peripheral types
-    #[serde_as(as = "Option<KeyValueMap<_>>")]
-    pub leds: Option<Vec<Led>>,
-    #[serde_as(as = "Option<KeyValueMap<_>>")]
-    pub buttons: Option<Vec<Button>>,
+    #[serde(default)]
+    pub leds: Vec<Led>,
+    #[serde(default)]
+    pub buttons: Vec<Button>,
     #[serde_as(as = "Option<KeyValueMap<_>>")]
     pub uarts: Option<Vec<Uart>>,
 }
@@ -74,20 +74,13 @@ pub struct Target {
 impl Target {
     #[must_use]
     pub fn has_leds(&self) -> bool {
-        if let Some(leds) = &self.leds {
-            !leds.is_empty()
-        } else {
-            false
-        }
+        !self.leds.is_empty()
     }
 
     #[must_use]
+
     pub fn has_buttons(&self) -> bool {
-        if let Some(buttons) = &self.buttons {
-            !buttons.is_empty()
-        } else {
-            false
-        }
+        !self.buttons.is_empty()
     }
 
     /// Returns true if there are any UARTs listed for this board.
@@ -110,13 +103,28 @@ impl Target {
             false
         }
     }
+
+    pub fn test_default() -> Self {
+        Self {
+            name: "test-target".to_string(),
+            ariel: ArielTargetExt::default(),
+            buttons: vec![],
+            chip: "test-chip".to_string(),
+            debugger: None,
+            description: None,
+            flags: BTreeSet::default(),
+            include: None,
+            leds: vec![],
+            quirks: vec![],
+            riot: RiotTargetExt::default(),
+            uarts: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Led {
-    #[serde(rename = "$key$")]
-    pub name: String,
     pub pin: String,
     pub color: Option<String>,
     pub active: Option<PinActive>,
@@ -127,8 +135,6 @@ pub struct Led {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Button {
-    #[serde(rename = "$key$")]
-    pub name: String,
     pub pin: String,
     pub active: Option<PinActive>,
     #[serde(default)]

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -67,8 +67,8 @@ pub struct Target {
     pub leds: Vec<Led>,
     #[serde(default)]
     pub buttons: Vec<Button>,
-    #[serde_as(as = "Option<KeyValueMap<_>>")]
-    pub uarts: Option<Vec<Uart>>,
+    #[serde(default)]
+    pub uarts: Vec<Uart>,
 }
 
 impl Target {
@@ -86,22 +86,14 @@ impl Target {
     /// Returns true if there are any UARTs listed for this board.
     #[must_use]
     pub fn has_uarts(&self) -> bool {
-        if let Some(uarts) = &self.uarts {
-            !uarts.is_empty()
-        } else {
-            false
-        }
+        !self.uarts.is_empty()
     }
 
     /// Returns true if there are any UARTs listed for this board that have the
     /// [`Uart::host_facing`] property.
     #[must_use]
     pub fn has_host_facing_uart(&self) -> bool {
-        if let Some(uarts) = &self.uarts {
-            uarts.iter().any(|u| u.host_facing)
-        } else {
-            false
-        }
+        self.uarts.iter().any(|u| u.host_facing)
     }
 
     pub fn test_default() -> Self {
@@ -117,7 +109,7 @@ impl Target {
             leds: vec![],
             quirks: vec![],
             riot: RiotTargetExt::default(),
-            uarts: None,
+            uarts: vec![],
         }
     }
 }
@@ -186,8 +178,8 @@ pub struct Debugger {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Uart {
-    #[serde(rename = "$key$")]
-    pub name: Option<String>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
     pub rx_pin: String,
     pub tx_pin: String,
     pub cts_pin: Option<String>,

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -67,8 +67,8 @@ pub struct Target {
     pub leds: Vec<Led>,
     #[serde(default)]
     pub buttons: Vec<Button>,
-    #[serde_as(as = "Option<KeyValueMap<_>>")]
-    pub uarts: Option<Vec<Uart>>,
+    #[serde(default)]
+    pub uarts: Vec<Uart>,
 }
 
 impl Target {
@@ -78,7 +78,6 @@ impl Target {
     }
 
     #[must_use]
-
     pub fn has_buttons(&self) -> bool {
         !self.buttons.is_empty()
     }
@@ -86,39 +85,14 @@ impl Target {
     /// Returns true if there are any UARTs listed for this board.
     #[must_use]
     pub fn has_uarts(&self) -> bool {
-        if let Some(uarts) = &self.uarts {
-            !uarts.is_empty()
-        } else {
-            false
-        }
+        !self.uarts.is_empty()
     }
 
     /// Returns true if there are any UARTs listed for this board that have the
     /// [`Uart::host_facing`] property.
     #[must_use]
     pub fn has_host_facing_uart(&self) -> bool {
-        if let Some(uarts) = &self.uarts {
-            uarts.iter().any(|u| u.host_facing)
-        } else {
-            false
-        }
-    }
-
-    pub fn test_default() -> Self {
-        Self {
-            name: "test-target".to_string(),
-            ariel: ArielTargetExt::default(),
-            buttons: vec![],
-            chip: "test-chip".to_string(),
-            debugger: None,
-            description: None,
-            flags: BTreeSet::default(),
-            include: None,
-            leds: vec![],
-            quirks: vec![],
-            riot: RiotTargetExt::default(),
-            uarts: None,
-        }
+        self.uarts.iter().any(|u| u.host_facing)
     }
 }
 
@@ -186,8 +160,8 @@ pub struct Debugger {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Uart {
-    #[serde(rename = "$key$")]
-    pub name: Option<String>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
     pub rx_pin: String,
     pub tx_pin: String,
     pub cts_pin: Option<String>,

--- a/crates/sbd-gen/sbd-test-files/nrf52840dk.yaml
+++ b/crates/sbd-gen/sbd-test-files/nrf52840dk.yaml
@@ -6,32 +6,23 @@ targets:
     flags:
       - has_usb_device_port
     leds:
-      led0:
+      - pin: P0_13
         color: green
-        pin: P0_13
         active: low
-      led1:
+      - pin: P0_14
         color: green
-        pin: P0_14
         active: low
-      led2:
+      - pin: P0_15
         color: green
-        pin: P0_15
-        active: low
-      led3:
+      - pin: P0_16
         color: green
-        pin: P0_16
 
     buttons:
-      button0:
-        pin: P0_11
+      - pin: P0_11
         active: low
-      button1:
-        pin: P0_12
+      - pin: P0_12
         active: low
-      button2:
-        pin: P0_24
+      - pin: P0_24
         active: low
-      button3:
-        pin: P0_25
+      - pin: P0_25
         active: low

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,9 +17,7 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{
-    Button, Led, PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
-};
+use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]
@@ -242,11 +240,11 @@ impl<'a> RenderTarget<'a> {
 
         if target.has_leds() || target.has_buttons() || target.has_uarts() {
             pins.push_str("use ariel_os_hal::hal::peripherals;\n\n");
-            if let Some(leds) = target.leds.as_ref() {
-                pins.push_str(&self.render_led_pins(leds)?);
+            if target.has_leds() {
+                pins.push_str(&self.render_led_pins()?);
             }
-            if let Some(buttons) = target.buttons.as_ref() {
-                pins.push_str(&self.render_button_pins(buttons)?);
+            if target.has_buttons() {
+                pins.push_str(&self.render_button_pins()?);
             }
             if target.uarts.is_some() {
                 pins.push_str(&self.render_uarts()?);
@@ -258,14 +256,16 @@ impl<'a> RenderTarget<'a> {
         Ok(pins)
     }
 
-    fn render_led_pins(&mut self, leds: &'a [Led]) -> Result<String> {
+    fn render_led_pins(&mut self) -> Result<String> {
+        let leds = &self.target.leds;
         let mut leds_rs = String::new();
 
         leds_rs.push_str("ariel_os_hal::define_peripherals!(LedPeripherals {\n");
 
-        for led in leds {
-            self.resources.claim(&led.pin, &led.name)?;
-            let _ = writeln!(leds_rs, "{}: {},", led.name, led.pin);
+        for (n, led) in leds.iter().enumerate() {
+            let name = format!("led{n}");
+            self.resources.claim(&led.pin, &name)?;
+            let _ = writeln!(leds_rs, "{}: {},", name, led.pin);
         }
 
         leds_rs.push_str("});\n");
@@ -273,14 +273,16 @@ impl<'a> RenderTarget<'a> {
         Ok(leds_rs)
     }
 
-    fn render_button_pins(&mut self, buttons: &'a [Button]) -> Result<String> {
+    fn render_button_pins(&mut self) -> Result<String> {
+        let buttons = &self.target.buttons;
         let mut buttons_rs = String::new();
 
         buttons_rs.push_str("ariel_os_hal::define_peripherals!(ButtonPeripherals {\n");
 
-        for button in buttons {
-            self.resources.claim(&button.pin, &button.name)?;
-            let _ = writeln!(buttons_rs, "{}: {},", button.name, button.pin);
+        for (n, button) in buttons.iter().enumerate() {
+            let name = format!("button{n}");
+            self.resources.claim(&button.pin, &name)?;
+            let _ = writeln!(buttons_rs, "{}: {},", name, button.pin);
         }
 
         buttons_rs.push_str("});\n");

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -246,7 +246,7 @@ impl<'a> RenderTarget<'a> {
             if target.has_buttons() {
                 pins.push_str(&self.render_button_pins()?);
             }
-            if target.uarts.is_some() {
+            if target.has_uarts() {
                 pins.push_str(&self.render_uarts()?);
             }
         }
@@ -291,17 +291,13 @@ impl<'a> RenderTarget<'a> {
     }
 
     fn render_uarts(&mut self) -> Result<String> {
-        let uarts = self.target.uarts.as_ref().unwrap();
+        let uarts = &self.target.uarts;
         let mut code = String::new();
 
         code.push_str("ariel_os_hal::define_uarts![\n");
 
-        for (uart_number, uart) in uarts.iter().enumerate() {
-            let name = uart.name.as_ref().map_or_else(
-                || format!("_unnamed_uart_{uart_number}").into(),
-                std::borrow::Cow::from,
-            );
-
+        for (n, uart) in uarts.iter().enumerate() {
+            let name = format!("uart{n}");
             {
                 // claim this UART's resources
                 // TODO: "by" could be more specific ("claimed by uart FOO as rx_pin" vs "claimed
@@ -445,9 +441,9 @@ pub fn test_default_target() -> Target {
 #[test]
 fn test_render_uarts() {
     use sbd_gen_schema::Uart;
-    let uarts = Some(vec![
+    let uarts = vec![
         Uart {
-            name: Some("CON0".to_string()),
+            aliases: vec!["CON0".to_string()],
             rx_pin: "PA08".to_owned(),
             tx_pin: "PC99".to_owned(),
             cts_pin: None,
@@ -456,7 +452,7 @@ fn test_render_uarts() {
             host_facing: false,
         },
         Uart {
-            name: Some("VCOM".to_string()),
+            aliases: vec!["VCOM".to_string()],
             rx_pin: "P0_04".to_owned(),
             tx_pin: "P1_23".to_owned(),
             cts_pin: Some("P7.89".to_owned()),
@@ -464,7 +460,7 @@ fn test_render_uarts() {
             possible_peripherals: vec!["UART1".to_owned(), "LEUART0".to_owned()],
             host_facing: true,
         },
-    ]);
+    ];
 
     let target = Target {
         uarts,
@@ -477,8 +473,8 @@ fn test_render_uarts() {
     assert_eq!(
         rendered,
         "ariel_os_hal::define_uarts![
-{ name: CON0, device: UART2, tx: PC99, rx: PA08, host_facing: false },
-{ name: VCOM, device: UART1, tx: P1_23, rx: P0_04, host_facing: true },
+{ name: uart0, device: UART2, tx: PC99, rx: PA08, host_facing: false },
+{ name: uart1, device: UART1, tx: P1_23, rx: P0_04, host_facing: true },
 ];
 "
     );

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,9 +17,7 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{
-    Button, Led, PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
-};
+use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]
@@ -241,11 +239,11 @@ impl<'a> RenderTarget<'a> {
         let target = self.target;
 
         if target.has_leds() || target.has_buttons() || target.has_uarts() {
-            if let Some(leds) = target.leds.as_ref() {
-                pins.push_str(&self.render_led_pins(leds)?);
+            if target.has_leds() {
+                pins.push_str(&self.render_led_pins()?);
             }
-            if let Some(buttons) = target.buttons.as_ref() {
-                pins.push_str(&self.render_button_pins(buttons)?);
+            if target.has_buttons() {
+                pins.push_str(&self.render_button_pins()?);
             }
             if target.uarts.is_some() {
                 pins.push_str(&self.render_uarts()?);
@@ -257,14 +255,16 @@ impl<'a> RenderTarget<'a> {
         Ok(pins)
     }
 
-    fn render_led_pins(&mut self, leds: &'a [Led]) -> Result<String> {
+    fn render_led_pins(&mut self) -> Result<String> {
+        let leds = &self.target.leds;
         let mut leds_rs = String::new();
 
         leds_rs.push_str("ariel_os_hal::define_peripherals!(LedPeripherals {\n");
 
-        for led in leds {
-            self.resources.claim(&led.pin, &led.name)?;
-            let _ = writeln!(leds_rs, "{}: {},", led.name, led.pin);
+        for (n, led) in leds.iter().enumerate() {
+            let name = format!("led{n}");
+            self.resources.claim(&led.pin, &name)?;
+            let _ = writeln!(leds_rs, "{}: {},", name, led.pin);
         }
 
         leds_rs.push_str("});\n");
@@ -272,14 +272,16 @@ impl<'a> RenderTarget<'a> {
         Ok(leds_rs)
     }
 
-    fn render_button_pins(&mut self, buttons: &'a [Button]) -> Result<String> {
+    fn render_button_pins(&mut self) -> Result<String> {
+        let buttons = &self.target.buttons;
         let mut buttons_rs = String::new();
 
         buttons_rs.push_str("ariel_os_hal::define_peripherals!(ButtonPeripherals {\n");
 
-        for button in buttons {
-            self.resources.claim(&button.pin, &button.name)?;
-            let _ = writeln!(buttons_rs, "{}: {},", button.name, button.pin);
+        for (n, button) in buttons.iter().enumerate() {
+            let name = format!("button{n}");
+            self.resources.claim(&button.pin, &name)?;
+            let _ = writeln!(buttons_rs, "{}: {},", name, button.pin);
         }
 
         buttons_rs.push_str("});\n");

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -245,7 +245,7 @@ impl<'a> RenderTarget<'a> {
             if target.has_buttons() {
                 pins.push_str(&self.render_button_pins()?);
             }
-            if target.uarts.is_some() {
+            if target.has_uarts() {
                 pins.push_str(&self.render_uarts()?);
             }
         }
@@ -290,17 +290,13 @@ impl<'a> RenderTarget<'a> {
     }
 
     fn render_uarts(&mut self) -> Result<String> {
-        let uarts = self.target.uarts.as_ref().unwrap();
+        let uarts = &self.target.uarts;
         let mut code = String::new();
 
         code.push_str("ariel_os_hal::define_uarts![\n");
 
-        for (uart_number, uart) in uarts.iter().enumerate() {
-            let name = uart.name.as_ref().map_or_else(
-                || format!("_unnamed_uart_{uart_number}").into(),
-                std::borrow::Cow::from,
-            );
-
+        for (n, uart) in uarts.iter().enumerate() {
+            let name = format!("uart{n}");
             {
                 // claim this UART's resources
                 // TODO: "by" could be more specific ("claimed by uart FOO as rx_pin" vs "claimed
@@ -428,14 +424,14 @@ pub fn test_default_target() -> Target {
     Target {
         name: "test-target".to_string(),
         ariel: sbd_gen_schema::ariel::ArielTargetExt::default(),
-        buttons: None,
+        buttons: vec![],
         chip: "test-chip".to_string(),
         debugger: None,
         description: None,
-        leds: None,
+        leds: vec![],
         flags: std::collections::BTreeSet::default(),
         include: None,
-        uarts: None,
+        uarts: vec![],
         quirks: vec![],
         riot: sbd_gen_schema::riot::RiotTargetExt::default(),
     }
@@ -444,9 +440,9 @@ pub fn test_default_target() -> Target {
 #[test]
 fn test_render_uarts() {
     use sbd_gen_schema::Uart;
-    let uarts = Some(vec![
+    let uarts = vec![
         Uart {
-            name: Some("CON0".to_string()),
+            aliases: vec!["CON0".to_string()],
             rx_pin: "PA08".to_owned(),
             tx_pin: "PC99".to_owned(),
             cts_pin: None,
@@ -455,7 +451,7 @@ fn test_render_uarts() {
             host_facing: false,
         },
         Uart {
-            name: Some("VCOM".to_string()),
+            aliases: vec!["VCOM".to_string()],
             rx_pin: "P0_04".to_owned(),
             tx_pin: "P1_23".to_owned(),
             cts_pin: Some("P7.89".to_owned()),
@@ -463,7 +459,7 @@ fn test_render_uarts() {
             possible_peripherals: vec!["UART1".to_owned(), "LEUART0".to_owned()],
             host_facing: true,
         },
-    ]);
+    ];
 
     let target = Target {
         uarts,
@@ -476,8 +472,8 @@ fn test_render_uarts() {
     assert_eq!(
         rendered,
         "ariel_os_hal::define_uarts![
-{ name: CON0, device: UART2, tx: PC99, rx: PA08, host_facing: false },
-{ name: VCOM, device: UART1, tx: P1_23, rx: P0_04, host_facing: true },
+{ name: uart0, device: UART2, tx: PC99, rx: PA08, host_facing: false },
+{ name: uart1, device: UART1, tx: P1_23, rx: P0_04, host_facing: true },
 ];
 "
     );

--- a/crates/sbd-gen/src/riot.rs
+++ b/crates/sbd-gen/src/riot.rs
@@ -203,10 +203,10 @@ fn generate_riot_target(sbd: &SbdFile, target: &Target) -> Result<RiotTarget> {
 
     // UARTs
     //let mut uart_isrs = Vec::new();
-    uarts.extend(target.uarts.iter().flatten());
+    uarts.extend(target.uarts.iter());
     let mut uart_peripherals = riot_chip.peripherals.as_ref().unwrap().uarts.clone();
     let mut uarts_configured = Vec::new();
-    for uart in uarts {
+    for (n, uart) in uarts.iter().enumerate() {
         // get the map key of the peripheral that works for this UART's pins
         #[expect(clippy::unnecessary_find_map)]
         let peripheral_key = uart_peripherals
@@ -228,11 +228,7 @@ fn generate_riot_target(sbd: &SbdFile, target: &Target) -> Result<RiotTarget> {
 
             uarts_configured.push((uart_cfg, uart_peripheral.isr));
         } else {
-            println!(
-                "warning: {}: no peripheral found for UART {}",
-                target.name,
-                uart.name.as_deref().unwrap_or("unnamed")
-            );
+            println!("warning: {}: no peripheral found for UART{n}", target.name);
         }
     }
 


### PR DESCRIPTION
This is schema breaking.

Makes the `led0...N` and `button0...N` names an implicit detail of the ariel generator.

Depends on ~~#140~~ (merged).

Accompanying Ariel OS PR: https://github.com/ariel-os/ariel-os/pull/2123

(this will fail the automatic ariel check, needs manual checkout & test)