### PR TITLE
feat(ariel)!: do not emit `ariel_os_hal::hal::peripherals` import

### DIFF
--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -241,7 +241,6 @@ impl<'a> RenderTarget<'a> {
         let target = self.target;
 
         if target.has_leds() || target.has_buttons() || target.has_uarts() {
-            pins.push_str("use ariel_os_hal::hal::peripherals;\n\n");
             if let Some(leds) = target.leds.as_ref() {
                 pins.push_str(&self.render_led_pins(leds)?);
             }

--- a/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
+++ b/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: crates/sbd-gen/src/main.rs
 expression: ariel
 ---
 FileMap {
@@ -8,7 +8,7 @@ FileMap {
         "build.rs": "// @generated\n\npub fn main() {\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"nrf52840dk\\\"))\");\n}\n",
         "laze.yml": "# yamllint disable-file\n\nbuilders:\n- name: nrf52840dk\n  parent: nrf52840\n  provides:\n  - has_buttons\n  - has_leds\n  - has_usb_device_port\n",
         "src/lib.rs": "// @generated\n\n#![no_std]\ncfg_if::cfg_if! {\n    if #[cfg(context = \"nrf52840dk\")] { include!(\"nrf52840dk.rs\"); } else {}\n}\n",
-        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    use ariel_os_hal::hal::peripherals;\n    ariel_os_hal::define_peripherals!(\n        LedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16, }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
+        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    ariel_os_hal::define_peripherals!(\n        LedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16, }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
     },
     tagfile: Some(
         ".sbd-gen",


### PR DESCRIPTION
https://github.com/ariel-os/ariel-os/pull/2120 improves `define_peripherals!()` to not need an extra import of `ariel_os_hal::hal::peripherals` anymore, so stop emitting it.

This is breaking, as code produced by this will not work with an Ariel OS version that has not been updated.