### PR TITLE
Bsp documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_with",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/crates/sbd-gen-schema/Cargo.toml
+++ b/crates/sbd-gen-schema/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*", "LICENSE-*"]
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { workspace = true }
 serde_with = { workspace = true }
+serde_yaml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use serde_with::{KeyValueMap, serde_as};
+use serde_yaml::Value as YamlValue;
 
 use crate::{
     ariel::{Ariel, ArielTargetExt},
@@ -16,6 +17,32 @@ use crate::{
 
 const fn default_version() -> Version {
     semver::Version::new(0, 2, 0)
+}
+
+/// Documentation metadata embedded in BSP files for use by documentation tooling.
+/// The content is intentionally opaque to sbd-gen; it is processed by external tools.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ArielDoc(YamlValue);
+
+impl Default for ArielDoc {
+    fn default() -> Self {
+        Self(YamlValue::Null)
+    }
+}
+
+impl PartialEq for ArielDoc {
+    fn eq(&self, other: &Self) -> bool {
+        serde_yaml::to_string(&self.0).ok() == serde_yaml::to_string(&other.0).ok()
+    }
+}
+
+impl Eq for ArielDoc {}
+
+impl std::hash::Hash for ArielDoc {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        serde_yaml::to_string(&self.0).ok().hash(state);
+    }
 }
 
 /// Returns the used schema version.
@@ -41,6 +68,7 @@ pub struct SbdFile {
     pub ariel: Option<Ariel>,
     pub riot: Option<Riot>,
     pub description: Option<String>,
+    pub ariel_doc: Option<ArielDoc>,
 }
 
 #[serde_as]


### PR DESCRIPTION
This is a parallel PR from Ariel-OS ariel-os/ariel-os#2161 which is dependent on this - here's the repeated context of that PR

Support matrix board and builder data is now sourced from ariel_doc sections in each BSP file under boards/. This eliminates the need to update two files when changing board metadata. The support_matrix.yml retains only global configuration (support_keys, functionalities, note_snippets, chips).

Depends on minor changes to sbd-gen

# Description

As more and more BSP yaml files are created and included as part of the OTS support from Ariel-OS its going to get unruly and cumbersome to edit multiple files (the BSP yaml and the documentation file in matrix_support.)  There may be other references in the documentation that can references the BSPs so those can also be examined in this PR. Also, there may be a better organizational way to do this, but I wanted to get this in place for discussion and testing. 

## Testing

`doc/gen_book.rs matrix doc/support_matrix.yml book/src/support_matrix.html --template-path book/templates/support-matrix.html.tmpl
`
## Issues/PRs References

This depends on a PR in sbd-gen to ignore arial_doc tree.

## Open Questions

Where else are BSPs details repeated in documentation

## Changelog Entry

Currently experimental to understand if this is valuable to others... I personally believe it is as I've been going down a rabbit hole trying to add all the open source hardware boards available to the Meshtastic stack for users to have an alternative solution with Ariel-OS.

## Change Checklist


- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
