### PR TITLE
feat: add various LED variants to the schema and  sdb-gen

### DIFF
--- a/crates/sbd-gen-schema/src/leds.rs
+++ b/crates/sbd-gen-schema/src/leds.rs
@@ -1,0 +1,88 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{PinActive, common::StringOrVecString};
+
+
+
+/// Monocolor LED.
+///
+///
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MonocolorLed {
+    #[serde(rename = "$key$")]
+    pub name: String,
+    /// Pin of the MCU connected to the LED.
+    pub pin: String,
+    /// Color of the LED.
+    pub color: Option<String>,
+    pub active: Option<PinActive>,
+    /// Possible aliases of the LED.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}
+
+/// Bicolor LED.
+///
+///
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BicolorLed {
+    #[serde(rename = "$key$")]
+    pub name: String,
+    /// Pins of the MCU connected to the LED.
+    pub pins: [String; 2],
+    /// Colors of the individual diodes of the bicolor led.
+    pub colors: Option<[String; 2]>,
+    pub active: Option<[PinActive; 2]>,
+    #[serde(default)]
+    /// Possible aliases of the LED.
+    pub aliases: Vec<String>,
+    /// Flag indicating if this is a LED with only two leads
+    /// and no connection to the ground.
+    #[serde(default)]
+    pub two_leads: bool,
+}
+
+/// LED Matrix using ROW + COL inputs to control ROW * COL outputs.
+///
+/// This does not make any assumptions on the phyiscal and geographical
+/// placement of the individual LEDs on the board. They maybe be wired in
+/// square matrix, in a diagonal array or any other geometrical arrangement.
+/// The only assumption is that the inputs are divided into two sets such that
+/// driving one of each lights up a single led.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LedMatrix {
+    #[serde(rename = "$key$")]
+    pub name: String,
+    /// Colors of each single LED or a single color if
+    /// every LED in the matrix have the same color.
+    pub colors: StringOrVecString,
+    /// set of "row" input pins.
+    pub row: Vec<String>,
+    /// set of "column" input pins.
+    pub col: Vec<String>,
+    /// Logical level required to activate the leds.
+    pub active: Option<PinActive>,
+    /// Aliases for the LED matrix.
+    #[serde(default)]
+    pub aliases: Vec<String>
+}
+
+/// LED using a single wire a serial communication protocol, also called a Smart-Pixel.
+///
+/// One or more pixel can be controlled from a single wire.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SmartLed {
+    #[serde(rename = "$key$")]
+    pub name: String,
+    /// Pin used for the serial communication protocol.
+    pub pin: String,
+    /// Number of addressable pixels.
+    pub size: usize,
+    /// Aliases for the smart pixel.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}

--- a/crates/sbd-gen-schema/src/leds.rs
+++ b/crates/sbd-gen-schema/src/leds.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{PinActive, common::StringOrVecString};
 
-
-
 /// Monocolor LED.
 ///
 ///
@@ -67,7 +65,7 @@ pub struct LedMatrix {
     pub active: Option<PinActive>,
     /// Aliases for the LED matrix.
     #[serde(default)]
-    pub aliases: Vec<String>
+    pub aliases: Vec<String>,
 }
 
 /// LED using a single wire a serial communication protocol, also called a Smart-Pixel.

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod ariel;
 pub mod common;
 pub mod riot;
+pub mod leds;
 
 use std::collections::BTreeSet;
 
@@ -9,9 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{KeyValueMap, serde_as};
 
 use crate::{
-    ariel::{Ariel, ArielTargetExt},
-    common::StringOrVecString,
-    riot::{Riot, RiotTargetExt},
+    ariel::{Ariel, ArielTargetExt}, common::StringOrVecString, leds::{MonocolorLed, SmartLed}, riot::{Riot, RiotTargetExt},
 };
 
 const fn default_version() -> Version {
@@ -26,7 +25,7 @@ const fn default_version() -> Version {
 /// In both cases, the schema version must be updated accordingly.
 #[must_use]
 pub const fn schema_version() -> Version {
-    semver::Version::new(0, 3, 1)
+    semver::Version::new(0, 3, 2)
 }
 
 #[serde_as]
@@ -64,9 +63,11 @@ pub struct Target {
 
     // peripheral types
     #[serde_as(as = "Option<KeyValueMap<_>>")]
-    pub leds: Option<Vec<Led>>,
+    pub leds: Option<Vec<MonocolorLed>>,
     #[serde_as(as = "Option<KeyValueMap<_>>")]
     pub buttons: Option<Vec<Button>>,
+    #[serde_as(as = "Option<KeyValueMap<_>>")]
+    pub smartleds: Option<Vec<SmartLed>>,
     #[serde_as(as = "Option<KeyValueMap<_>>")]
     pub uarts: Option<Vec<Uart>>,
 }

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod ariel;
 pub mod common;
-pub mod riot;
 pub mod leds;
+pub mod riot;
 
 use std::collections::BTreeSet;
 
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 use serde_with::{KeyValueMap, serde_as};
 
 use crate::{
-    ariel::{Ariel, ArielTargetExt}, common::StringOrVecString, leds::{MonocolorLed, SmartLed}, riot::{Riot, RiotTargetExt},
+    ariel::{Ariel, ArielTargetExt},
+    common::StringOrVecString,
+    leds::{MonocolorLed, SmartLed},
+    riot::{Riot, RiotTargetExt},
 };
 
 const fn default_version() -> Version {

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -18,10 +18,9 @@ use crate::{
 };
 
 use sbd_gen_schema::{
-    Button, PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
-    leds::{
-        MonocolorLed, LedMatrix, SmartLed, BicolorLed,
-    }
+    Button, PinLevel, Quirk, SbdFile, SetPinOp, Target,
+    common::StringOrVecString,
+    leds::{BicolorLed, LedMatrix, MonocolorLed, SmartLed},
 };
 
 #[derive(argh::FromArgs, Debug)]
@@ -287,9 +286,20 @@ impl<'a> RenderTarget<'a> {
         for led in leds {
             self.resources.claim(&led.pins[0], &led.name)?;
             self.resources.claim(&led.pins[1], &led.name)?;
-            let colors_or_number = led.colors.clone().unwrap_or([String::from("1"), String::from("2")]);
-            let _ = writeln!(leds_rs, "{}_{}: {},", led.name, colors_or_number[0], led.pins[0]);
-            let _ = writeln!(leds_rs, "{}_{}: {},", led.name, colors_or_number[1], led.pins[1]);
+            let colors_or_number = led
+                .colors
+                .clone()
+                .unwrap_or([String::from("1"), String::from("2")]);
+            let _ = writeln!(
+                leds_rs,
+                "{}_{}: {},",
+                led.name, colors_or_number[0], led.pins[0]
+            );
+            let _ = writeln!(
+                leds_rs,
+                "{}_{}: {},",
+                led.name, colors_or_number[1], led.pins[1]
+            );
         }
 
         leds_rs.push_str("});\n");
@@ -302,23 +312,35 @@ impl<'a> RenderTarget<'a> {
 
         for led_matrix in leds {
             // Define "Row pins" for the LED Matrix
-            let _ = writeln!(leds_rs, "ariel_os_hal::define_peripherals!({}RowPins {{", led_matrix.name);
+            let _ = writeln!(
+                leds_rs,
+                "ariel_os_hal::define_peripherals!({}RowPins {{",
+                led_matrix.name
+            );
             for (i, pin) in led_matrix.row.iter().enumerate() {
                 self.resources.claim(pin, &led_matrix.name)?;
-                let _ = writeln!(leds_rs, "p_r{}: {},", i, pin);
+                let _ = writeln!(leds_rs, "p_r{i}: {pin},");
             }
             let _ = writeln!(leds_rs, "}});");
 
             // Define "Column pins" for the LED Matrix
-            let _ = writeln!(leds_rs, "ariel_os_hal::define_peripherals!({}ColumnPins {{", led_matrix.name);
+            let _ = writeln!(
+                leds_rs,
+                "ariel_os_hal::define_peripherals!({}ColumnPins {{",
+                led_matrix.name
+            );
             for (i, pin) in led_matrix.col.iter().enumerate() {
                 self.resources.claim(pin, &led_matrix.name)?;
-                let _ = writeln!(leds_rs, "p_r{}: {},", i, pin);
+                let _ = writeln!(leds_rs, "p_r{i}: {pin},");
             }
             let _ = write!(leds_rs, "}});");
 
             // Group row and column peripherals in a single
-            let _ = write!(leds_rs, "ariel_os_hal::group_peripherals!({} {{", led_matrix.name);
+            let _ = write!(
+                leds_rs,
+                "ariel_os_hal::group_peripherals!({} {{",
+                led_matrix.name
+            );
             let _ = writeln!(leds_rs, "rows: {}RowPins,", led_matrix.name);
             let _ = writeln!(leds_rs, "cols: {}ColumnPins,", led_matrix.name);
             let _ = writeln!(leds_rs, "}});");
@@ -501,6 +523,7 @@ pub fn test_default_target() -> Target {
         debugger: None,
         description: None,
         leds: None,
+        smartleds: None,
         flags: std::collections::BTreeSet::default(),
         include: None,
         uarts: None,

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -18,7 +18,10 @@ use crate::{
 };
 
 use sbd_gen_schema::{
-    Button, Led, PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
+    Button, PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
+    leds::{
+        MonocolorLed, LedMatrix, SmartLed, BicolorLed,
+    }
 };
 
 #[derive(argh::FromArgs, Debug)]
@@ -243,7 +246,10 @@ impl<'a> RenderTarget<'a> {
         if target.has_leds() || target.has_buttons() || target.has_uarts() {
             pins.push_str("use ariel_os_hal::hal::peripherals;\n\n");
             if let Some(leds) = target.leds.as_ref() {
-                pins.push_str(&self.render_led_pins(leds)?);
+                pins.push_str(&self.render_monocolor_led_pins(leds)?);
+            }
+            if let Some(leds) = target.smartleds.as_ref() {
+                pins.push_str(&self.render_smartled_pins(leds)?);
             }
             if let Some(buttons) = target.buttons.as_ref() {
                 pins.push_str(&self.render_button_pins(buttons)?);
@@ -258,10 +264,73 @@ impl<'a> RenderTarget<'a> {
         Ok(pins)
     }
 
-    fn render_led_pins(&mut self, leds: &'a [Led]) -> Result<String> {
+    fn render_monocolor_led_pins(&mut self, leds: &'a [MonocolorLed]) -> Result<String> {
         let mut leds_rs = String::new();
 
-        leds_rs.push_str("ariel_os_hal::define_peripherals!(LedPeripherals {\n");
+        leds_rs.push_str("ariel_os_hal::define_peripherals!(MonocolorLedPeripherals {\n");
+
+        for led in leds {
+            self.resources.claim(&led.pin, &led.name)?;
+            let _ = writeln!(leds_rs, "{}: {},", led.name, led.pin);
+        }
+
+        leds_rs.push_str("});\n");
+
+        Ok(leds_rs)
+    }
+
+    fn render_bicolor_led_pins(&mut self, leds: &'a [BicolorLed]) -> Result<String> {
+        let mut leds_rs = String::new();
+
+        leds_rs.push_str("ariel_os_hal::define_peripherals!(BicolorLedPeripherals {\n");
+
+        for led in leds {
+            self.resources.claim(&led.pins[0], &led.name)?;
+            self.resources.claim(&led.pins[1], &led.name)?;
+            let colors_or_number = led.colors.clone().unwrap_or([String::from("1"), String::from("2")]);
+            let _ = writeln!(leds_rs, "{}_{}: {},", led.name, colors_or_number[0], led.pins[0]);
+            let _ = writeln!(leds_rs, "{}_{}: {},", led.name, colors_or_number[1], led.pins[1]);
+        }
+
+        leds_rs.push_str("});\n");
+
+        Ok(leds_rs)
+    }
+
+    fn render_led_matrix_pins(&mut self, leds: &'a [LedMatrix]) -> Result<String> {
+        let mut leds_rs = String::new();
+
+        for led_matrix in leds {
+            // Define "Row pins" for the LED Matrix
+            let _ = writeln!(leds_rs, "ariel_os_hal::define_peripherals!({}RowPins {{", led_matrix.name);
+            for (i, pin) in led_matrix.row.iter().enumerate() {
+                self.resources.claim(pin, &led_matrix.name)?;
+                let _ = writeln!(leds_rs, "p_r{}: {},", i, pin);
+            }
+            let _ = writeln!(leds_rs, "}});");
+
+            // Define "Column pins" for the LED Matrix
+            let _ = writeln!(leds_rs, "ariel_os_hal::define_peripherals!({}ColumnPins {{", led_matrix.name);
+            for (i, pin) in led_matrix.col.iter().enumerate() {
+                self.resources.claim(pin, &led_matrix.name)?;
+                let _ = writeln!(leds_rs, "p_r{}: {},", i, pin);
+            }
+            let _ = write!(leds_rs, "}});");
+
+            // Group row and column peripherals in a single
+            let _ = write!(leds_rs, "ariel_os_hal::group_peripherals!({} {{", led_matrix.name);
+            let _ = writeln!(leds_rs, "rows: {}RowPins,", led_matrix.name);
+            let _ = writeln!(leds_rs, "cols: {}ColumnPins,", led_matrix.name);
+            let _ = writeln!(leds_rs, "}});");
+        }
+
+        Ok(leds_rs)
+    }
+
+    fn render_smartled_pins(&mut self, leds: &'a [SmartLed]) -> Result<String> {
+        let mut leds_rs = String::new();
+
+        leds_rs.push_str("ariel_os_hal::define_peripherals!(SmartLedPeripherals {\n");
 
         for led in leds {
             self.resources.claim(&led.pin, &led.name)?;

--- a/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
+++ b/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
@@ -1,5 +1,5 @@
 ---
-source: src/main.rs
+source: crates/sbd-gen/src/main.rs
 expression: ariel
 ---
 FileMap {
@@ -8,7 +8,7 @@ FileMap {
         "build.rs": "// @generated\n\npub fn main() {\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"nrf52840dk\\\"))\");\n}\n",
         "laze.yml": "# yamllint disable-file\n\nbuilders:\n- name: nrf52840dk\n  parent: nrf52840\n  provides:\n  - has_buttons\n  - has_leds\n  - has_usb_device_port\n",
         "src/lib.rs": "// @generated\n\n#![no_std]\ncfg_if::cfg_if! {\n    if #[cfg(context = \"nrf52840dk\")] { include!(\"nrf52840dk.rs\"); } else {}\n}\n",
-        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    use ariel_os_hal::hal::peripherals;\n    ariel_os_hal::define_peripherals!(\n        LedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16, }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
+        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    use ariel_os_hal::hal::peripherals;\n    ariel_os_hal::define_peripherals!(\n        MonocolorLedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16,\n        }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
     },
     tagfile: Some(
         ".sbd-gen",


### PR DESCRIPTION
This is a draft implementation of the ideas discussed in #152. 
Many questions remain at this stage including:
- What's the biggest `XcolorLed` we should go to ? 
- How to integrate with the `has_leds` flag ? 
