### PR TITLE
ci: add formatting check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint
       run: cargo clippy --locked
+    - name: Format
+      run: cargo fmt --all --check
     - name: Build
       run: cargo build
     - name: Run tests


### PR DESCRIPTION
This PR adds a `rustfmt` check to the CI to ensure consistent formatting in the codebase.