### PR TITLE
refactor(leds): Rename `Led` to `MonocolorLed` 

### DIFF
--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Target {
 
     // peripheral types
     #[serde(default)]
-    pub leds: Vec<Led>,
+    pub leds: Vec<MonocolorLed>,
     #[serde(default)]
     pub buttons: Vec<Button>,
     #[serde(default)]
@@ -98,7 +98,7 @@ impl Target {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Led {
+pub struct MonocolorLed {
     pub pin: String,
     pub color: Option<String>,
     pub active: Option<PinActive>,

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,7 +17,9 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
+use sbd_gen_schema::{
+    PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
+};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]
@@ -259,7 +261,7 @@ impl<'a> RenderTarget<'a> {
         let leds = &self.target.leds;
         let mut leds_rs = String::new();
 
-        leds_rs.push_str("ariel_os_hal::define_peripherals!(LedPeripherals {\n");
+        leds_rs.push_str("ariel_os_hal::define_peripherals!(MonocolorLedPeripherals {\n");
 
         for (n, led) in leds.iter().enumerate() {
             let name = format!("led{n}");

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,9 +17,7 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{
-    PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
-};
+use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]

--- a/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
+++ b/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
@@ -8,7 +8,7 @@ FileMap {
         "build.rs": "// @generated\n\npub fn main() {\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"nrf52840dk\\\"))\");\n}\n",
         "laze.yml": "# yamllint disable-file\n\nbuilders:\n- name: nrf52840dk\n  parent: nrf52840\n  provides:\n  - has_buttons\n  - has_leds\n  - has_usb_device_port\n",
         "src/lib.rs": "// @generated\n\n#![no_std]\ncfg_if::cfg_if! {\n    if #[cfg(context = \"nrf52840dk\")] { include!(\"nrf52840dk.rs\"); } else {}\n}\n",
-        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    ariel_os_hal::define_peripherals!(\n        LedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16, }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
+        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    ariel_os_hal::define_peripherals!(\n        MonocolorLedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16,\n        }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
     },
     tagfile: Some(
         ".sbd-gen",


### PR DESCRIPTION
This PR renames `Led` to `MonocolorLed` in preparation for the additions to sbd discussed in #152 and #160

<del>This PR is a breaking change and requires changing the already existing sbd files.</del>