### PR TITLE
feat(leds): Support packages with more than one diode

### DIFF
--- a/crates/sbd-gen-schema/src/led.rs
+++ b/crates/sbd-gen-schema/src/led.rs
@@ -4,6 +4,23 @@
 use crate::PinActive;
 use serde::{Deserialize, Serialize};
 
+/// Dispatching enum between different types of LEDs
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Led {
+    /// Monocolor LEDs
+    Monocolor(MonocolorLed),
+    /// Duocolor LEDs
+    Duocolor(DuocolorLed),
+    /// Tricolor LEDs
+    Tricolor(TricolorLed),
+    /// Tetracolor LEDs
+    Tetracolor(TetracolorLed),
+    /// Pentacolor LEDs
+    Pentacolor(PentacolorLed),
+}
+
+
 /// Monocolor LED.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -13,6 +30,79 @@ pub struct MonocolorLed {
     /// Color of the LED.
     pub color: Option<String>,
     /// Whether the LED is active high or low.
+    pub active: Option<PinActive>,
+    /// Possible aliases of the LED.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}
+
+/// Duocolor LED.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DuocolorLed {
+    /// Pins of the MCU connected to the LED.
+    pub pins: [String; 2],
+    /// Color of the LED.
+    pub colors: Option<[String; 2]>,
+    /// Whether the LED is active high or low.
+    /// We assume that it is the same for each pin.
+    pub active: Option<PinActive>,
+    /// Possible aliases of the LED.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}
+
+/// Tricolor LED.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TricolorLed {
+    /// Pins of the MCU connected to the LED.
+    pub pins: [String; 3],
+    /// Color of the LED.
+    pub colors: Option<[String; 3]>,
+    /// Whether the LED is active high or low.
+    /// We assume that it is the same for each pin.
+    pub active: Option<PinActive>,
+    /// Possible aliases of the LED.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}
+
+/// Tetracolor LED.
+///
+/// This is meant to be used for:
+/// - RGBA (RGB plus Amber).
+/// - RGBCW/RGBW (RGB plus Cool White).
+/// - RGBWW (RGB plus Warm White).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TetracolorLed {
+    /// Pins of the MCU connected to the LED.
+    pub pins: [String; 4],
+    /// Color of the LED.
+    pub colors: Option<[String; 4]>,
+    /// Whether the LED is active high or low.
+    /// We assume that it is the same for each pin.
+    pub active: Option<PinActive>,
+    /// Possible aliases of the LED.
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}
+
+/// Pentacolor LED.
+///
+/// This is meant to be used for:
+/// - RGBACW (RGB plus Amber plus cool white)
+/// - RGB-CW-WW (RGB plus Cool White plus Warm White)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PentacolorLed {
+    /// Pins of the MCU connected to the LED.
+    pub pins: [String; 5],
+    /// Color of the LED.
+    pub colors: Option<[String; 5]>,
+    /// Whether the LED is active high or low.
+    /// We assume that it is the same for each pin.
     pub active: Option<PinActive>,
     /// Possible aliases of the LED.
     #[serde(default)]

--- a/crates/sbd-gen-schema/src/led.rs
+++ b/crates/sbd-gen-schema/src/led.rs
@@ -1,0 +1,12 @@
+use crate::PinActive;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MonocolorLed {
+    pub pin: String,
+    pub color: Option<String>,
+    pub active: Option<PinActive>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}

--- a/crates/sbd-gen-schema/src/led.rs
+++ b/crates/sbd-gen-schema/src/led.rs
@@ -1,12 +1,20 @@
+#![deny(missing_docs)]
+//! Light emitting devices consisting of Light emitting diodes (LED).
+
 use crate::PinActive;
 use serde::{Deserialize, Serialize};
 
+/// Monocolor LED.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MonocolorLed {
+    /// Pin of the MCU connected to the LED.
     pub pin: String,
+    /// Color of the LED.
     pub color: Option<String>,
+    /// Whether the LED is active high or low.
     pub active: Option<PinActive>,
+    /// Possible aliases of the LED.
     #[serde(default)]
     pub aliases: Vec<String>,
 }

--- a/crates/sbd-gen-schema/src/led.rs
+++ b/crates/sbd-gen-schema/src/led.rs
@@ -20,7 +20,6 @@ pub enum Led {
     Pentacolor(PentacolorLed),
 }
 
-
 /// Monocolor LED.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Target {
 
     // peripheral types
     #[serde(default)]
-    pub leds: Vec<Led>,
+    pub leds: Vec<MonocolorLed>,
     #[serde(default)]
     pub buttons: Vec<Button>,
     #[serde(default)]
@@ -98,7 +98,7 @@ impl Target {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Led {
+pub struct MonocolorLed {
     pub pin: String,
     pub color: Option<String>,
     pub active: Option<PinActive>,

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
     riot::{Riot, RiotTargetExt},
 };
 
-pub use led::{DuocolorLed, MonocolorLed, PentacolorLed, TetracolorLed, TricolorLed, Led};
+pub use led::{DuocolorLed, Led, MonocolorLed, PentacolorLed, TetracolorLed, TricolorLed};
 
 const fn default_version() -> Version {
     semver::Version::new(0, 2, 0)

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
     riot::{Riot, RiotTargetExt},
 };
 
-pub use led::MonocolorLed;
+pub use led::{DuocolorLed, MonocolorLed, PentacolorLed, TetracolorLed, TricolorLed, Led};
 
 const fn default_version() -> Version {
     semver::Version::new(0, 2, 0)
@@ -29,7 +29,7 @@ const fn default_version() -> Version {
 /// In both cases, the schema version must be updated accordingly.
 #[must_use]
 pub const fn schema_version() -> Version {
-    semver::Version::new(0, 4, 0)
+    semver::Version::new(0, 4, 1)
 }
 
 #[serde_as]
@@ -67,7 +67,7 @@ pub struct Target {
 
     // peripheral types
     #[serde(default)]
-    pub leds: Vec<MonocolorLed>,
+    pub leds: Vec<Led>,
     #[serde(default)]
     pub buttons: Vec<Button>,
     #[serde(default)]

--- a/crates/sbd-gen-schema/src/lib.rs
+++ b/crates/sbd-gen-schema/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ariel;
 pub mod common;
+pub mod led;
 pub mod riot;
 
 use std::collections::BTreeSet;
@@ -13,6 +14,8 @@ use crate::{
     common::StringOrVecString,
     riot::{Riot, RiotTargetExt},
 };
+
+pub use led::MonocolorLed;
 
 const fn default_version() -> Version {
     semver::Version::new(0, 2, 0)
@@ -94,16 +97,6 @@ impl Target {
     pub fn has_host_facing_uart(&self) -> bool {
         self.uarts.iter().any(|u| u.host_facing)
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct MonocolorLed {
-    pub pin: String,
-    pub color: Option<String>,
-    pub active: Option<PinActive>,
-    #[serde(default)]
-    pub aliases: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/sbd-gen/sbd-test-files/leds-variants.yaml
+++ b/crates/sbd-gen/sbd-test-files/leds-variants.yaml
@@ -1,0 +1,51 @@
+version: 0.4.1
+description: sbd test file for LED variants
+targets:
+  board-with-lots-of-leds:
+    chip: nrf52840
+    leds:
+      # Monocolor LED
+      - pin: P0_13
+        color: green
+        active: low
+      # Duocolor LED
+      - pins:
+        - P0_14
+        - P0_15
+        colors:
+          - red
+          - green
+        active: low
+      # Tricolor LED
+      - pins:
+        - P0_16
+        - P0_17
+        - P0_18
+        colors:
+        - red
+        - green
+        - blue
+      # Tetracolor LED
+      - pins:
+        - P0_19
+        - P0_20
+        - P0_21
+        - P0_22
+        colors:
+        - red
+        - green
+        - blue
+        - amber
+      # Pentacolor LED
+      - pins:
+        - P0_23
+        - P0_24
+        - P0_25
+        - P0_26
+        - P0_27
+        colors:
+        - red
+        - green
+        - blue
+        - warm white
+        - cool whit

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,7 +17,7 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString, Led};
+use sbd_gen_schema::{Led, PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]
@@ -305,7 +305,6 @@ impl<'a> RenderTarget<'a> {
                     let _ = writeln!(leds_rs, "{}_4: {}", name, &penta.pins[4]);
                 }
             }
-
         }
 
         leds_rs.push_str("});\n");

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,7 +17,7 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
+use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString, Led};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]
@@ -263,8 +263,49 @@ impl<'a> RenderTarget<'a> {
 
         for (n, led) in leds.iter().enumerate() {
             let name = format!("led{n}");
-            self.resources.claim(&led.pin, &name)?;
-            let _ = writeln!(leds_rs, "{}: {},", name, led.pin);
+            match led {
+                Led::Monocolor(mono) => {
+                    self.resources.claim(&mono.pin, &name)?;
+                    let _ = writeln!(leds_rs, "{}: {},", name, mono.pin);
+                }
+                Led::Duocolor(duo) => {
+                    self.resources.claim(&duo.pins[0], &name)?;
+                    self.resources.claim(&duo.pins[1], &name)?;
+                    let _ = writeln!(leds_rs, "{}_0: {}", name, &duo.pins[0]);
+                    let _ = writeln!(leds_rs, "{}_1: {}", name, &duo.pins[1]);
+                }
+                Led::Tricolor(trio) => {
+                    self.resources.claim(&trio.pins[0], &name)?;
+                    self.resources.claim(&trio.pins[1], &name)?;
+                    self.resources.claim(&trio.pins[2], &name)?;
+                    let _ = writeln!(leds_rs, "{}_0: {}", name, &trio.pins[0]);
+                    let _ = writeln!(leds_rs, "{}_1: {}", name, &trio.pins[1]);
+                    let _ = writeln!(leds_rs, "{}_2: {}", name, &trio.pins[2]);
+                }
+                Led::Tetracolor(tetra) => {
+                    self.resources.claim(&tetra.pins[0], &name)?;
+                    self.resources.claim(&tetra.pins[1], &name)?;
+                    self.resources.claim(&tetra.pins[2], &name)?;
+                    self.resources.claim(&tetra.pins[3], &name)?;
+                    let _ = writeln!(leds_rs, "{}_0: {}", name, &tetra.pins[0]);
+                    let _ = writeln!(leds_rs, "{}_1: {}", name, &tetra.pins[1]);
+                    let _ = writeln!(leds_rs, "{}_2: {}", name, &tetra.pins[2]);
+                    let _ = writeln!(leds_rs, "{}_3: {}", name, &tetra.pins[3]);
+                }
+                Led::Pentacolor(penta) => {
+                    self.resources.claim(&penta.pins[0], &name)?;
+                    self.resources.claim(&penta.pins[1], &name)?;
+                    self.resources.claim(&penta.pins[2], &name)?;
+                    self.resources.claim(&penta.pins[3], &name)?;
+                    self.resources.claim(&penta.pins[4], &name)?;
+                    let _ = writeln!(leds_rs, "{}_0: {}", name, &penta.pins[0]);
+                    let _ = writeln!(leds_rs, "{}_1: {}", name, &penta.pins[1]);
+                    let _ = writeln!(leds_rs, "{}_2: {}", name, &penta.pins[2]);
+                    let _ = writeln!(leds_rs, "{}_3: {}", name, &penta.pins[3]);
+                    let _ = writeln!(leds_rs, "{}_4: {}", name, &penta.pins[4]);
+                }
+            }
+
         }
 
         leds_rs.push_str("});\n");

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,7 +17,9 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
+use sbd_gen_schema::{
+    PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
+};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]
@@ -259,7 +261,7 @@ impl<'a> RenderTarget<'a> {
         let leds = &self.target.leds;
         let mut leds_rs = String::new();
 
-        leds_rs.push_str("ariel_os_hal::define_peripherals!(LedPeripherals {\n");
+        leds_rs.push_str("ariel_os_hal::define_peripherals!(MonocolorLedPeripherals {\n");
 
         for (n, led) in leds.iter().enumerate() {
             let name = format!("led{n}");

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -17,9 +17,7 @@ use crate::{
     resources::Resources,
 };
 
-use sbd_gen_schema::{
-    PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString,
-};
+use sbd_gen_schema::{PinLevel, Quirk, SbdFile, SetPinOp, Target, common::StringOrVecString};
 
 #[derive(argh::FromArgs, Debug)]
 #[argh(subcommand, name = "generate-ariel")]

--- a/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
+++ b/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
@@ -5,9 +5,10 @@ expression: ariel
 FileMap {
     map: {
         "Cargo.toml": "# @generated\n\n[package]\nname = \"ariel-os-boards\"\n\n[package.edition]\nworkspace = true\n\n[package.license]\nworkspace = true\n\n[package.rust-version]\nworkspace = true\n\n[dependencies.ariel-os-embassy-common]\nworkspace = true\n\n[dependencies.ariel-os-hal]\nworkspace = true\n\n[dependencies.cfg-if]\nworkspace = true\n\n[features]\nno-boards = []\n",
-        "build.rs": "// @generated\n\npub fn main() {\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"nrf52840dk\\\"))\");\n}\n",
-        "laze.yml": "# yamllint disable-file\n\nbuilders:\n- name: nrf52840dk\n  parent: nrf52840\n  provides:\n  - has_buttons\n  - has_leds\n  - has_usb_device_port\n",
-        "src/lib.rs": "// @generated\n\n#![no_std]\ncfg_if::cfg_if! {\n    if #[cfg(context = \"nrf52840dk\")] { include!(\"nrf52840dk.rs\"); } else {}\n}\n",
+        "build.rs": "// @generated\n\npub fn main() {\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"board-with-lots-of-leds\\\"))\");\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"nrf52840dk\\\"))\");\n}\n",
+        "laze.yml": "# yamllint disable-file\n\nbuilders:\n- name: board-with-lots-of-leds\n  parent: nrf52840\n  provides:\n  - has_leds\n- name: nrf52840dk\n  parent: nrf52840\n  provides:\n  - has_buttons\n  - has_leds\n  - has_usb_device_port\n",
+        "src/board-with-lots-of-leds.rs": "// @generated\n\npub mod pins {\n    ariel_os_hal::define_peripherals!(\n        MonocolorLedPeripherals { led0 : P0_13, led1_0 : P0_14 led1_1 : P0_15 led2_0 :\n        P0_16 led2_1 : P0_17 led2_2 : P0_18 led3_0 : P0_19 led3_1 : P0_20 led3_2 : P0_21\n        led3_3 : P0_22 led4_0 : P0_23 led4_1 : P0_24 led4_2 : P0_25 led4_3 : P0_26 led4_4\n        : P0_27 }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
+        "src/lib.rs": "// @generated\n\n#![no_std]\ncfg_if::cfg_if! {\n    if #[cfg(context = \"board-with-lots-of-leds\")] {\n    include!(\"board-with-lots-of-leds.rs\"); } else if #[cfg(context = \"nrf52840dk\")] {\n    include!(\"nrf52840dk.rs\"); } else {}\n}\n",
         "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    ariel_os_hal::define_peripherals!(\n        MonocolorLedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16,\n        }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
     },
     tagfile: Some(

--- a/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
+++ b/crates/sbd-gen/src/snapshots/sbd_gen__tests__sbd_ariel.snap
@@ -8,7 +8,7 @@ FileMap {
         "build.rs": "// @generated\n\npub fn main() {\n    println!(\"cargo::rustc-check-cfg=cfg(context, values(\\\"nrf52840dk\\\"))\");\n}\n",
         "laze.yml": "# yamllint disable-file\n\nbuilders:\n- name: nrf52840dk\n  parent: nrf52840\n  provides:\n  - has_buttons\n  - has_leds\n  - has_usb_device_port\n",
         "src/lib.rs": "// @generated\n\n#![no_std]\ncfg_if::cfg_if! {\n    if #[cfg(context = \"nrf52840dk\")] { include!(\"nrf52840dk.rs\"); } else {}\n}\n",
-        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    ariel_os_hal::define_peripherals!(\n        LedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16, }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
+        "src/nrf52840dk.rs": "// @generated\n\npub mod pins {\n    ariel_os_hal::define_peripherals!(\n        MonocolorLedPeripherals { led0 : P0_13, led1 : P0_14, led2 : P0_15, led3 : P0_16,\n        }\n    );\n    ariel_os_hal::define_peripherals!(\n        ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :\n        P0_25, }\n    );\n}\n#[allow(unused_variables)]\npub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}\n",
     },
     tagfile: Some(
         ".sbd-gen",


### PR DESCRIPTION
This PR adds support for light emitting devices consisting of more than diode. This has been extracted and refactored from #160 and comes from the discussion at #152. 

Depends on #163 

 ## Open questions:
 - RGBCCT LEds have a dimmer for the color temperature controls. Is the `PentacolorLed` good enough for this ? I could not find info on how they are usually wired and controlled

