### PR TITLE
ci(compile-check): make the check not run on `main` where it may fail

### DIFF
--- a/.github/workflows/compile-generated-files.yml
+++ b/.github/workflows/compile-generated-files.yml
@@ -1,8 +1,6 @@
 name: Compile generated files
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
This makes the compile check that runs against Ariel OS SBD files *only* run for PRs, not on `main`, because it may fail there where Ariel OS SBD files are not updated (in case of breaking changes), which they cannot be at this point. For PRs there is a label that allows skipping that check.