### PR TITLE
fix!: make `uart{n}` `Uart{n}`

### DIFF
--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -296,7 +296,9 @@ impl<'a> RenderTarget<'a> {
         code.push_str("ariel_os_hal::define_uarts![\n");
 
         for (n, uart) in uarts.iter().enumerate() {
-            let name = format!("uart{n}");
+            // This name is used to generate a type so it needs to
+            // be in UpperCamelCase.
+            let name = format!("Uart{n}");
             {
                 // claim this UART's resources
                 // TODO: "by" could be more specific ("claimed by uart FOO as rx_pin" vs "claimed

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -474,8 +474,8 @@ fn test_render_uarts() {
     assert_eq!(
         rendered,
         "ariel_os_hal::define_uarts![
-{ name: uart0, device: UART2, tx: PC99, rx: PA08, host_facing: false },
-{ name: uart1, device: UART1, tx: P1_23, rx: P0_04, host_facing: true },
+{ name: Uart0, device: UART2, tx: PC99, rx: PA08, host_facing: false },
+{ name: Uart1, device: UART1, tx: P1_23, rx: P0_04, host_facing: true },
 ];
 "
     );

--- a/crates/sbd-gen/src/ariel.rs
+++ b/crates/sbd-gen/src/ariel.rs
@@ -296,9 +296,7 @@ impl<'a> RenderTarget<'a> {
         code.push_str("ariel_os_hal::define_uarts![\n");
 
         for (n, uart) in uarts.iter().enumerate() {
-            // This name is used to generate a type so it needs to
-            // be in UpperCamelCase.
-            let name = format!("Uart{n}");
+            let name = format!("uart{n}");
             {
                 // claim this UART's resources
                 // TODO: "by" could be more specific ("claimed by uart FOO as rx_pin" vs "claimed
@@ -335,10 +333,12 @@ impl<'a> RenderTarget<'a> {
 
             // Deferring to a macro so that any actual logic in there is handled in the OS where it
             // belongs; this merely processes the data into a format usable there.
+            // Note: the name of the uart is not used because rust requires type names to
+            // be UpperCamelCase.
             writeln!(
                 code,
-                "{{ name: {}, device: {}, tx: {}, rx: {}, host_facing: {} }},",
-                name, device, uart.tx_pin, uart.rx_pin, uart.host_facing
+                "{{ name: Uart{}, device: {}, tx: {}, rx: {}, host_facing: {} }},",
+                n, device, uart.tx_pin, uart.rx_pin, uart.host_facing
             )
             .unwrap();
         }


### PR DESCRIPTION
In `generate-ariel` `sbd-gen` uses an implicit name for uart that is then used as a struct. This name should thus be in UpperCamelCase which it wasn't. This PR fixes this. 